### PR TITLE
added the "|" symbol to a category title rule (ref: https://basecamp.com...

### DIFF
--- a/apps/frontend/config/seo.yml
+++ b/apps/frontend/config/seo.yml
@@ -67,7 +67,7 @@ seo:
       title:
         - %Name% | Collectors Quest
         - %Name% Collections | Collectors Quest
-        - %Name% Antique Collectible & Vintage | Collectors Quest
+        - %Name% | Antique Collectible & Vintage | Collectors Quest
       description: |
         Browse collectible, vintage and antique items on Collectors Quest,
         like these %Name% items, posted by trusted sellers and passionate collectors!


### PR DESCRIPTION
Please push this to production (a symbol I forgot to originally add to the Title rule)
