### PR TITLE
Marketplace sidebar - do not show categories with only few Items 

### DIFF
--- a/apps/frontend/modules/_sidebar/actions/components.class.php
+++ b/apps/frontend/modules/_sidebar/actions/components.class.php
@@ -121,8 +121,30 @@ class _sidebarComponents extends cqFrontendComponents
       ->filterByLevel(array(1, 2))
       ->hasCollectiblesForSale()
       ->orderBy('Name', Criteria::ASC);
+    $categories = $q->find();
 
-    $this->categories = $q->find();
+    // if we have less than 4 Items For Sale in the category we don't want to display it
+    $this->categories = array();
+    foreach ($categories as $category)
+    {
+      /** @var $q CollectibleForSaleQuery */
+      $q = CollectibleForSaleQuery::create()
+        ->useCollectibleQuery()
+          ->filterByIsPublic(true)
+        ->endUse();
+
+      $q->filterByContentCategoryWithDescendants($category)
+        ->isForSale();
+
+      // how many items for sale are there in the category
+      $count_items = $q->count();
+
+      // if we have more at least 4 items we display the category in the widget
+      if ($count_items >= 4)
+      {
+        $this->categories[] = $category;
+      }
+    }
 
     return $this->_sidebar_if(count($this->categories) > 0);
   }


### PR DESCRIPTION
Do not show categories in widget "Explore the Market" on
the /marketplace page unless they have 4 or more Items for Sale

Ref: https://basecamp.com/1759305/projects/19290-collectorsquest-com/todos/16206702-do-not-show
