### PR TITLE
Shadowbox appears only in posts on single image

### DIFF
--- a/web/blog/wp-content/themes/collectorsquest/footer.php
+++ b/web/blog/wp-content/themes/collectorsquest/footer.php
@@ -5,6 +5,6 @@ if(typeof(networkedblogs)=="undefined"){networkedblogs = {};networkedblogs.blogI
 </script><script src="http://nwidget.networkedblogs.com/getnetworkwidget?bid=493033" type="text/javascript"></script>
 
 <script type="text/javascript">
-    $('div.post a img').parent().attr('rel','shadowbox');
-    $('.gallery-icon a').attr('rel','');
+  $('div.singular div.post a img').parent().attr('rel','shadowbox');
+  $('.gallery-icon a').attr('rel','');
 </script>


### PR DESCRIPTION
Clicking on images from the blog homepage and other pages does
not open the links in Shadowbox any more
Ref:
https://basecamp.com/1759305/projects/281910-collectorsquest-com/todos/17306409-clicking-on-the
