### PR TITLE
Other items in this Collection

### DIFF
--- a/apps/frontend/modules/_sidebar/actions/components.class.php
+++ b/apps/frontend/modules/_sidebar/actions/components.class.php
@@ -840,6 +840,14 @@ class _sidebarComponents extends cqFrontendComponents
       $this->collectibles = $pager->getResults();
     }
 
+    if (count($this->collectibles) == 1 && $pager->haveToPaginate())
+    {
+      $position = $this->collectibles->getFirst()->getPosition();
+      $this->collectibles = $a
+        ->filterByPosition(array($position - 2, $position - 1, $position), Criteria::IN)
+        ->find();
+    }
+
     $this->pager = $pager;
     $this->collection = $collection;
     $this->collectible = $collectible;


### PR DESCRIPTION
When we are on the last item of the collection, we need to display the previous two items, and not empty space like now.

Ref: https://basecamp.com/1759305/projects/281910-collectorsquest-com/todos/20118042-other-items-in-this
